### PR TITLE
Use `Gles3` backend when targeting `WasmEmscripten`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,7 +80,7 @@ fn select_sokol_backend(build: &mut cc::Build, config: &CompilationConfig) -> So
             BuildTarget::Linux => SokolBackend::Gl,
             BuildTarget::Windows => SokolBackend::D3d11,
             BuildTarget::Macos => SokolBackend::Metal,
-            BuildTarget::WasmEmscripten => SokolBackend::Gles2,
+            BuildTarget::WasmEmscripten => SokolBackend::Gles3,
         },
 
         "D3D11" => SokolBackend::D3d11,
@@ -253,7 +253,14 @@ fn make_sokol() {
             }
         },
 
-        BuildTarget::WasmEmscripten => {},
+        BuildTarget::WasmEmscripten => {
+            match backend {
+                SokolBackend::Gles3 => {
+                    println!("cargo:rustc-link-arg=-sUSE_WEBGL2");
+                },
+                _ => {},
+            }
+        },
     }
 
     build.compile("sokol-rust");


### PR DESCRIPTION
Fixes https://github.com/floooh/sokol-rust/issues/10

~~This fixes the build error and generates correct-looking files, but I haven't actually tested them.~~

Tested and working.
![image](https://github.com/floooh/sokol-rust/assets/530129/e097c8b6-6458-411d-90c5-48f6fb01068e)
