### PR TITLE
emscripten: Enable webgpu for SOKOL_BACKEND=WGPU.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -257,6 +257,9 @@ fn make_sokol() {
             SokolBackend::Gles3 => {
                 println!("cargo:rustc-link-arg=-sUSE_WEBGL2");
             },
+            SokolBackend::Wgpu => {
+                println!("cargo:rustc-link-arg=-sUSE_WEBGPU");
+            },
             _ => {},
         },
     }


### PR DESCRIPTION
When I try to confirm that this works, I get errors, but the generated code looks like it is referencing WebGPU at least. Have you tried this out before?